### PR TITLE
[Feat] 유저 주소록 페이지 QA 반영

### DIFF
--- a/src/api/action/address-book.ts
+++ b/src/api/action/address-book.ts
@@ -1,22 +1,15 @@
-import ApiManager, { ApiManagerSingleton } from '@/services/ApiManger';
+import { ApiManagerSingleton } from '@/services/ApiManger';
 import * as addressBookTypes from '@/types/address-book-types';
 import * as commonTypes from '@/types/common-types';
 
 // * 일반 요청
 const $httpFactory = ApiManagerSingleton.getInstance({
-	baseURL: process.env.NEXT_PUBLIC_SERVER_URL + 'setting/',
+	baseURL: process.env.NEXT_PUBLIC_SERVER_URL,
 	timeout: 10000,
 	headers: {
 		Authorization: 'Bearer ' + process.env.NEXT_PUBLIC_TOKEN,
 	},
 });
-
-// * 중복 및 유저 확인 요청 (서버 url 따로)
-const $httpFactoryForCheck = new ApiManager(process.env.NEXT_PUBLIC_CHECK_URL);
-$httpFactoryForCheck.timeout = 10000;
-$httpFactoryForCheck.headers = {
-	Authorization: 'Bearer ' + process.env.NEXT_PUBLIC_TOKEN,
-};
 
 // * 주소록 조회
 export const getAddressBook = async <T = addressBookTypes.GetAddressBookResponse>(
@@ -24,7 +17,7 @@ export const getAddressBook = async <T = addressBookTypes.GetAddressBookResponse
 ): Promise<commonTypes.responseApi<T>> => {
 	try {
 		const response: commonTypes.responseApi<T> = await $httpFactory.getRequest({
-			url: 'contact/group',
+			url: 'setting/contact/group',
 			data: {
 				page: queryString.page,
 			},
@@ -45,8 +38,8 @@ export const checkDuplicateGroupTitle = async <T = addressBookTypes.CheckDuplica
 	queryString: addressBookTypes.CheckDuplicateGroupTitleQueryString,
 ): Promise<commonTypes.responseApi<T>> => {
 	try {
-		const response: commonTypes.responseApi<T> = await $httpFactoryForCheck.getRequest({
-			url: 'contact/group/check',
+		const response: commonTypes.responseApi<T> = await $httpFactory.getRequest({
+			url: 'setting/contact/group/check',
 			data: queryString,
 		});
 		return response;
@@ -66,7 +59,7 @@ export const createAddressBook = async <T = addressBookTypes.CreateAddressBookRe
 ): Promise<commonTypes.responseApi<T>> => {
 	try {
 		const response: commonTypes.responseApi<T> = await $httpFactory.postRequest({
-			url: 'contact/group',
+			url: 'setting/contact/group',
 			data: request,
 		});
 		return response;
@@ -85,8 +78,8 @@ export const searchUser = async <T = addressBookTypes.SearchUserResponse>(
 	queryString: addressBookTypes.SearchUserQueryString,
 ): Promise<commonTypes.responseApi<T>> => {
 	try {
-		const response: commonTypes.responseApi<T> = await $httpFactoryForCheck.getRequest({
-			url: 'contact',
+		const response: commonTypes.responseApi<T> = await $httpFactory.getRequest({
+			url: 'setting/contact',
 			data: queryString,
 		});
 		return response;
@@ -107,7 +100,7 @@ export const updateAddressBook = async <T = addressBookTypes.UpdateAddressBookRe
 ): Promise<commonTypes.responseApi<T>> => {
 	try {
 		const response: commonTypes.responseApi<T> = await $httpFactory.postRequest({
-			url: `contact/group/${id}`,
+			url: `setting/contact/group/${id}`,
 			data: request,
 		});
 		return response;
@@ -127,7 +120,7 @@ export const deleteAddressBook = async <T = addressBookTypes.DeleteAddressBookRe
 ): Promise<commonTypes.responseApi<T>> => {
 	try {
 		const response: commonTypes.responseApi<T> = await $httpFactory.postRequest({
-			url: `contact/group/delete/${request.id}`,
+			url: `setting/contact/group/delete/${request.id}`,
 		});
 		return response;
 	} catch (error: unknown) {

--- a/src/api/tanstack-query/useAddressBook.ts
+++ b/src/api/tanstack-query/useAddressBook.ts
@@ -6,13 +6,13 @@ import * as addressBookTypes from '@/types/address-book-types';
 import { createAddressBook, getAddressBook, checkDuplicateGroupTitle, searchUser, updateAddressBook, deleteAddressBook } from '../action/address-book';
 
 // * 주소록 목록 조회
-const useGetAddressBooks = (queryString: addressBookTypes.GetAddressBookQueryString): UseQueryResult<addressBookTypes.GetAddressBookResponse | undefined> => {
+const useGetAddressBooks = (queryString: addressBookTypes.GetAddressBookQueryString): UseQueryResult<addressBookTypes.GetAddressBookResponse | null> => {
 	return useQuery({
 		queryKey: ['addressBook', queryString.page],
 		queryFn: async () => {
-			const response = await getAddressBook(queryString);
+			const response = await getAddressBook<addressBookTypes.GetAddressBookResponse>(queryString);
 			if (response.statusCode === 200) {
-				return response.result || undefined;
+				return response.result;
 			}
 			throw new Error(response.message);
 		},
@@ -50,14 +50,14 @@ const useCreateAddressBook = (request: addressBookTypes.CreateAddressBookRequest
 			}
 		},
 		onSuccess: () => {
-				toast.success('주소록이 성공적으로 생성되었습니다.');
+			toast.success('주소록이 성공적으로 생성되었습니다.');
 			queryClient.invalidateQueries({ queryKey: ['addressBook'] });
 		},
 		onError: error => {
 			if (error.message === '중복된 그룹명입니다.') {
 				toast.error('중복된 그룹명입니다.');
 			} else {
-			toast.error('주소록 생성에 실패했습니다. 다시 시도해주세요.');
+				toast.error('주소록 생성에 실패했습니다. 다시 시도해주세요.');
 			}
 		},
 	});
@@ -68,13 +68,13 @@ const useSearchUser = (queryString: addressBookTypes.SearchUserQueryString): Use
 	return useMutation({
 		mutationKey: ['searchUser', queryString.email],
 		mutationFn: async () => {
-			const response = await searchUser(queryString);
+			const response = await searchUser<addressBookTypes.SearchUserResponse>(queryString);
 			if (response.statusCode === 200) {
 				return response.result || undefined;
 			}
-
+		},
+		onError: () => {
 			toast.error('사용자 검색에 실패했습니다. 다시 시도해주세요.');
-			throw new Error(response.message);
 		},
 	});
 };
@@ -109,14 +109,14 @@ const useUpdateAddressBook = (
 			}
 		},
 		onSuccess: () => {
-				toast.success('주소록이 성공적으로 업데이트되었습니다.');
+			toast.success('주소록이 성공적으로 업데이트되었습니다.');
 			queryClient.invalidateQueries({ queryKey: ['addressBook'] });
 		},
 		onError: error => {
 			if (error.message === '중복된 그룹명입니다.') {
 				toast.error(error.message);
 			} else {
-			toast.error('주소록 업데이트에 실패했습니다. 다시 시도해주세요.');
+				toast.error('주소록 업데이트에 실패했습니다. 다시 시도해주세요.');
 			}
 		},
 	});

--- a/src/app/user/_components/TopMenu.tsx
+++ b/src/app/user/_components/TopMenu.tsx
@@ -15,9 +15,9 @@ const TopMenu = () => {
 	return (
 		<div className="border-stroke flex h-[6rem] w-full flex-row items-end gap-[3rem] border-b px-[2rem]">
 			<TopMenuItem title="주소록" href="/user/address-book" />
-			<TopMenuItem title="이상탐지 설정" href="operation-incident-setting" disabled />
-			<TopMenuItem title="기타 설정" href="etc-setting" disabled />
-			<TopMenuItem title="엑셀 양식 관리" href="excel-form-management" disabled />
+			<TopMenuItem title="이상탐지 설정" href="#" />
+			<TopMenuItem title="기타 설정" href="#" />
+			<TopMenuItem title="엑셀 양식 관리" href="#" />
 		</div>
 	);
 };
@@ -38,17 +38,17 @@ interface TopMenuItemProps {
 	disabled?: boolean;
 }
 
-const TopMenuItem = ({ title, href, disabled }: TopMenuItemProps) => {
+const TopMenuItem = ({ title, href }: TopMenuItemProps) => {
 	const pathname = usePathname();
-
-	if (disabled) {
-		return <div className="flex h-[2.9rem] cursor-not-allowed items-start text-[1.7rem]">{title}</div>;
-	}
 
 	return (
 		<Link
 			href={href}
-			className={cn('flex h-[2.9rem] items-start text-[1.7rem]', pathname === href && 'text-primary border-b-primary border-b-[3px] font-semibold')}
+			className={cn(
+				'flex h-[2.9rem] items-start text-[1.7rem]',
+				pathname === href && 'text-primary border-b-primary border-b-[3px] font-semibold',
+				href === '#' && 'cursor-not-allowed',
+			)}
 		>
 			{title}
 		</Link>

--- a/src/app/user/address-book/_components/AddressBookDialog.tsx
+++ b/src/app/user/address-book/_components/AddressBookDialog.tsx
@@ -53,7 +53,7 @@ const AddressBookDialog = ({ mode, contactGroup }: AddressBookDialogProps) => {
 					<TableRow className="[&>*]:border-stroke h-[4.8rem] text-[1.4rem] hover:bg-[#EBEEFB] [&>*]:border-r [&>*]:border-b [&>*]:px-[1.5rem] [&>*:last-child]:border-r-0">
 						<TableCell>{contactGroup?.name}</TableCell>
 						<TableCell>{contactGroup?.contactCount}</TableCell>
-						<TableCell className="w-[6.3rem] text-center">
+						<TableCell className="text-center">
 							<div onClick={e => e.stopPropagation()}>
 								<DeleteConfirmDialog id={contactGroup?.id || 0} />
 							</div>

--- a/src/app/user/address-book/_components/AddressBookDialog.tsx
+++ b/src/app/user/address-book/_components/AddressBookDialog.tsx
@@ -12,7 +12,7 @@ import { Dialog, DialogTitle, DialogContent, DialogHeader, DialogTrigger, Dialog
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { TableCell, TableRow } from '@/components/ui/table';
-import { ContactGroup } from '@/types/address-book-types';
+import * as addressBookTypes from '@/types/address-book-types';
 
 /**
  * @component 주소록 다이얼로그 컴포넌트
@@ -24,7 +24,7 @@ import { ContactGroup } from '@/types/address-book-types';
 
 interface AddressBookDialogProps {
 	mode: 'add' | 'edit';
-	contactGroup?: ContactGroup;
+	contactGroup?: addressBookTypes.ContactGroup;
 }
 
 const AddressBookDialog = ({ mode, contactGroup }: AddressBookDialogProps) => {

--- a/src/app/user/address-book/_components/AddressBookTable.tsx
+++ b/src/app/user/address-book/_components/AddressBookTable.tsx
@@ -22,13 +22,13 @@ const AddressBookTable = ({
 	isAddressBookError: boolean;
 }) => {
 	return (
-		<Table>
+		<Table className="table-fixed">
 			<TableHeader className="border-stroke h-[4.8rem] border-y bg-[#EDEDED] font-bold [&>*]:hover:bg-transparent">
 				<TableRow className="[&>*]:border-stroke text-[1.4rem] [&>*]:border-r [&>*]:px-[1.5rem] [&>*]:font-bold [&>*:last-child]:border-r-0">
-					<TableHead className="w-[45%]">그룹명</TableHead>
-					<TableHead className="w-[45%]">직원수</TableHead>
+					<TableHead className="max-w-[84.2rem]">그룹명</TableHead>
+					<TableHead className="max-w-[84.2rem]">직원수</TableHead>
 					{/* 삭제 버튼 열 */}
-					<TableHead className="w-[10%]">&nbsp;</TableHead>
+					<TableHead className="w-[6.3rem] max-w-[6.3rem] flex-shrink-0">&nbsp;</TableHead>
 				</TableRow>
 			</TableHeader>
 			<TableBody>

--- a/src/app/user/address-book/_components/AddressBookTable.tsx
+++ b/src/app/user/address-book/_components/AddressBookTable.tsx
@@ -1,7 +1,7 @@
 import AddressBookDialog from '@/app/user/address-book/_components/AddressBookDialog';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { ContactGroup } from '@/types/address-book-types';
+import * as addressBookTypes from '@/types/address-book-types';
 
 /**
  * @component 주소록 테이블 컴포넌트
@@ -17,7 +17,7 @@ const AddressBookTable = ({
 	isAddressBookLoading,
 	isAddressBookError,
 }: {
-	contactGroups: ContactGroup[];
+	contactGroups: addressBookTypes.ContactGroup[];
 	isAddressBookLoading: boolean;
 	isAddressBookError: boolean;
 }) => {

--- a/src/app/user/address-book/_components/DeleteConfirmDialog.tsx
+++ b/src/app/user/address-book/_components/DeleteConfirmDialog.tsx
@@ -16,8 +16,12 @@ const DeleteConfirmDialog = ({ id }: { id: number }) => {
 	const { mutateAsync: deleteAddressBook, isPending: isDeleting } = useDeleteAddressBook(id);
 
 	const handleDelete = async () => {
+		try {
 		await deleteAddressBook({});
-		handleDialogChange(false);
+			// eslint-disable-next-line unused-imports/no-unused-vars
+		} catch (error) {
+			// 훅에서 error toast 처리
+		}
 	};
 
 	const handleOpenChange = (open: boolean) => {
@@ -43,6 +47,7 @@ const DeleteConfirmDialog = ({ id }: { id: number }) => {
 						variant="outline"
 						className="h-[4.1rem] w-[9rem] rounded-[1rem] px-[1.5rem] py-[1rem] text-[1.7rem] font-bold"
 						onClick={() => handleDialogChange(false)}
+						disabled={isDeleting}
 					>
 						취소
 					</Button>

--- a/src/app/user/address-book/_components/DeleteConfirmDialog.tsx
+++ b/src/app/user/address-book/_components/DeleteConfirmDialog.tsx
@@ -17,7 +17,7 @@ const DeleteConfirmDialog = ({ id }: { id: number }) => {
 
 	const handleDelete = async () => {
 		try {
-		await deleteAddressBook({});
+			await deleteAddressBook({});
 			// eslint-disable-next-line unused-imports/no-unused-vars
 		} catch (error) {
 			// 훅에서 error toast 처리

--- a/src/app/user/address-book/_hooks/useAddressBookDialog.ts
+++ b/src/app/user/address-book/_hooks/useAddressBookDialog.ts
@@ -1,6 +1,6 @@
 import { useCreateAddressBook, useUpdateAddressBook } from '@/api/tanstack-query/useAddressBook';
 import useDialog from '@/components/hooks/useDialog';
-import { Contact, ContactGroup } from '@/types/address-book-types';
+import * as addressBookTypes from '@/types/address-book-types';
 
 /**
  * @component 주소록 다이얼로그 훅
@@ -19,8 +19,8 @@ interface UseAddressBookDialogProps {
 	resetInput: () => void;
 	restoreFromServerData: () => void;
 	name: string;
-	contacts: Contact[];
-	contactGroup?: ContactGroup;
+	contacts: addressBookTypes.Contact[];
+	contactGroup?: addressBookTypes.ContactGroup;
 }
 
 const useAddressBookDialog = ({ mode, resetInput, restoreFromServerData, name, contacts, contactGroup }: UseAddressBookDialogProps) => {

--- a/src/app/user/address-book/_hooks/useContactManagement.ts
+++ b/src/app/user/address-book/_hooks/useContactManagement.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useSearchUser } from '@/api/tanstack-query/useAddressBook';
-import { Contact } from '@/types/address-book-types';
+import * as addressBookTypes from '@/types/address-book-types';
 
 /**
  * @component 연락처 관리 훅
@@ -19,8 +19,8 @@ interface UseContactManagementProps {
 	email: string;
 	setEmail: (email: string) => void;
 	setEmailWarningMessage: (emailWarningMessage: string) => void;
-	contacts: Contact[];
-	setContacts: (contacts: Contact[]) => void;
+	contacts: addressBookTypes.Contact[];
+	setContacts: (contacts: addressBookTypes.Contact[]) => void;
 }
 
 const useContactManagement = ({ email, setEmail, setEmailWarningMessage, contacts, setContacts }: UseContactManagementProps) => {

--- a/src/app/user/address-book/page.tsx
+++ b/src/app/user/address-book/page.tsx
@@ -2,14 +2,11 @@
 
 import { useState } from 'react';
 
-import { toast } from 'sonner';
-
 import { useGetAddressBooks } from '@/api/tanstack-query/useAddressBook';
 import Breadcrumb from '@/app/user/_components/Breadcrumb';
 import AddressBookDialog from '@/app/user/address-book/_components/AddressBookDialog';
 import AddressBookTable from '@/app/user/address-book/_components/AddressBookTable';
 import AddressBookTablePagination from '@/app/user/address-book/_components/AddressBookTablePagination';
-import { Button } from '@/components/ui/button';
 
 const AddressBookPage = () => {
 	const [page, setPage] = useState(0);
@@ -25,9 +22,6 @@ const AddressBookPage = () => {
 			<div className="flex flex-row items-center justify-between">
 				<Breadcrumb topMenuTitle="주소록" sideMenuTitle="개인화 설정" />
 				<AddressBookDialog mode="add" />
-				<Button variant="default" size="default" onClick={() => toast.success('테스트')}>
-					테스트
-				</Button>
 			</div>
 
 			{/* 주소록 테이블 */}

--- a/src/app/user/address-book/page.tsx
+++ b/src/app/user/address-book/page.tsx
@@ -41,8 +41,8 @@ const AddressBookPage = () => {
 					previousPage={addressBook?.perviousPage || 0}
 					nowPage={addressBook?.nowPage || 0}
 					nextPage={addressBook?.nextPage || null}
-					pageSize={addressBook?.pageSize || 10}
-					totalRows={addressBook?.totalRows || 10}
+					pageSize={addressBook?.pageSize || 1}
+					totalRows={addressBook?.totalRows || 1}
 					onPageChange={handlePageChange}
 				/>
 			</div>

--- a/src/components/icons/ArrowDown.tsx
+++ b/src/components/icons/ArrowDown.tsx
@@ -1,6 +1,8 @@
-export const ArrowDown = ({ className }: { className?: string }) => (
+const ArrowDown = ({ className }: { className?: string }) => (
 	<svg width="9" height="13" viewBox="0 0 9 13" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
 		<line x1="4.69922" y1="0.911133" x2="4.69922" y2="12.2386" stroke="currentColor" />
 		<path d="M8.1737 8.78039L4.71289 12.2412L1.25208 8.78039" stroke="currentColor" strokeLinecap="round" />
 	</svg>
 );
+
+export default ArrowDown;

--- a/src/components/icons/BpaLogo.tsx
+++ b/src/components/icons/BpaLogo.tsx
@@ -1,4 +1,4 @@
-export const BpaLogo = ({ className }: { className?: string }) => (
+const BpaLogo = ({ className }: { className?: string }) => (
 	<svg width="63.95" height="14.6" viewBox="0 0 64 16" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
 		<path
 			d="M46.9106 1.36462H41.1906L33.1523 15.0661H36.7593L38.5849 11.9487H47.6876L49.5701 15.0661H55.1637L46.9106 1.36462ZM40.2052 9.19131L43.092 4.26726L46.0547 9.19131H40.2052Z"
@@ -15,3 +15,5 @@ export const BpaLogo = ({ className }: { className?: string }) => (
 		<path d="M51.8086 1.36157H63.9782L57.9771 11.595L51.8086 1.36157Z" fill="#F08300" />
 	</svg>
 );
+
+export default BpaLogo;

--- a/src/components/icons/ChevronLeft.tsx
+++ b/src/components/icons/ChevronLeft.tsx
@@ -1,5 +1,7 @@
-export const ChevronLeft = ({ className }: { className?: string }) => (
+const ChevronLeft = ({ className }: { className?: string }) => (
 	<svg width="6" height="10" viewBox="0 0 6 10" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
 		<path d="M4.99955 0.757359L0.756906 5L4.99955 9.24264" stroke="currentColor" strokeLinecap="round" />
 	</svg>
 );
+
+export default ChevronLeft;

--- a/src/components/icons/ChevronRight.tsx
+++ b/src/components/icons/ChevronRight.tsx
@@ -1,5 +1,7 @@
-export const ChevronRight = ({ className }: { className?: string }) => (
+const ChevronRight = ({ className }: { className?: string }) => (
 	<svg width="6" height="10" viewBox="0 0 6 10" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
 		<path d="M0.777797 0.757359L5.02044 5L0.777797 9.24264" stroke="currentColor" strokeLinecap="round" />
 	</svg>
 );
+
+export default ChevronRight;

--- a/src/components/icons/ChevronsLeft.tsx
+++ b/src/components/icons/ChevronsLeft.tsx
@@ -1,6 +1,8 @@
-export const ChevronsLeft = ({ className }: { className?: string }) => (
+const ChevronsLeft = ({ className }: { className?: string }) => (
 	<svg width="15" height="10" viewBox="0 0 15 10" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
 		<path d="M10.5191 0.757359L6.27644 5L10.5191 9.24264" stroke="currentColor" strokeLinecap="round" />
 		<path d="M5.0347 0.757359L0.792062 5L5.0347 9.24264" stroke="currentColor" strokeLinecap="round" />
 	</svg>
 );
+
+export default ChevronsLeft;

--- a/src/components/icons/ChevronsRight.tsx
+++ b/src/components/icons/ChevronsRight.tsx
@@ -1,6 +1,8 @@
-export const ChevronsRight = ({ className }: { className?: string }) => (
+const ChevronsRight = ({ className }: { className?: string }) => (
 	<svg width="16" height="10" viewBox="0 0 16 10" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
 		<path d="M5.03561 0.757359L9.27825 5L5.03561 9.24264" stroke="currentColor" strokeLinecap="round" />
 		<path d="M10.52 0.757359L14.7626 5L10.52 9.24264" stroke="currentColor" strokeLinecap="round" />
 	</svg>
 );
+
+export default ChevronsRight;

--- a/src/components/icons/Close.tsx
+++ b/src/components/icons/Close.tsx
@@ -1,6 +1,8 @@
-export const Close = ({ className }: { className?: string }) => (
+const Close = ({ className }: { className?: string }) => (
 	<svg width="15" height="16" viewBox="0 0 15 16" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
 		<path d="M13.5 1.86328L7.5 7.86328L13.5 13.8633" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
 		<path d="M1.5 1.86328L7.5 7.86328L1.5 13.8633" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
 	</svg>
 );
+
+export default Close;

--- a/src/components/icons/Container.tsx
+++ b/src/components/icons/Container.tsx
@@ -1,4 +1,4 @@
-export const Container = ({ className }: { className?: string }) => (
+const Container = ({ className }: { className?: string }) => (
 	<svg width="29" height="23" viewBox="0 0 29 23" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
 		<line x1="8.04102" y1="11.655" x2="8.04102" y2="17.5498" stroke="currentColor" strokeWidth="2" />
 		<line x1="13.084" y1="11.655" x2="13.084" y2="17.5498" stroke="currentColor" strokeWidth="2" />
@@ -17,3 +17,5 @@ export const Container = ({ className }: { className?: string }) => (
 		<line y1="-1" x2="4.64431" y2="-1" transform="matrix(0.720403 0.693556 -0.720403 0.693556 24.1973 9.79346)" stroke="currentColor" strokeWidth="2" />
 	</svg>
 );
+
+export default Container;

--- a/src/components/icons/Schedule.tsx
+++ b/src/components/icons/Schedule.tsx
@@ -1,4 +1,4 @@
-export const Schedule = ({ className }: { className?: string }) => (
+const Schedule = ({ className }: { className?: string }) => (
 	<svg width="24" height="26" viewBox="0 0 24 26" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
 		<line x1="1.06055" y1="9.49719" x2="23.0333" y2="9.49719" stroke="currentColor" strokeWidth="2" />
 		<line x1="5.68555" y1="15.1222" x2="7.77087" y2="15.1222" stroke="currentColor" strokeWidth="2" />
@@ -12,3 +12,5 @@ export const Schedule = ({ className }: { className?: string }) => (
 		<rect x="1.34961" y="3.23157" width="21.2997" height="21.2997" stroke="currentColor" strokeWidth="2" />
 	</svg>
 );
+
+export default Schedule;

--- a/src/components/icons/ShipMonitoring.tsx
+++ b/src/components/icons/ShipMonitoring.tsx
@@ -1,4 +1,4 @@
-export const ShipMonitoring = ({ className }: { className?: string }) => (
+const ShipMonitoring = ({ className }: { className?: string }) => (
 	<svg width="31" height="29" viewBox="0 0 31 29" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
 		<path d="M6.55664 13.9331V5.87878H13.4984V2.41528" stroke="currentColor" strokeWidth="2" />
 		<path d="M2.10938 16.4498L13.4166 9.90576L24.7237 16.4498L20.1849 27.4883H13.4166H6.6482L2.10938 16.4498Z" stroke="currentColor" strokeWidth="2" />
@@ -16,3 +16,5 @@ export const ShipMonitoring = ({ className }: { className?: string }) => (
 		<line x1="6.55273" y1="8.90576" x2="9.40083" y2="8.90576" stroke="currentColor" strokeWidth="2" />
 	</svg>
 );
+
+export default ShipMonitoring;

--- a/src/components/icons/Statistics.tsx
+++ b/src/components/icons/Statistics.tsx
@@ -1,4 +1,4 @@
-export const Statistics = ({ className }: { className?: string }) => (
+const Statistics = ({ className }: { className?: string }) => (
 	<svg width="32" height="23" viewBox="0 0 32 23" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
 		<rect x="4.14453" y="13.447" width="5.13324" height="8.03244" stroke="currentColor" strokeWidth="2" />
 		<rect x="13.4297" y="8.43628" width="5.13324" height="13.0432" stroke="currentColor" strokeWidth="2" />
@@ -6,3 +6,5 @@ export const Statistics = ({ className }: { className?: string }) => (
 		<line x1="0.986328" y1="21.4797" x2="31.0122" y2="21.4797" stroke="currentColor" strokeWidth="2" />
 	</svg>
 );
+
+export default Statistics;

--- a/src/components/icons/User.tsx
+++ b/src/components/icons/User.tsx
@@ -1,4 +1,4 @@
-export const User = ({ className }: { className?: string }) => (
+const User = ({ className }: { className?: string }) => (
 	<svg width="26" height="26" viewBox="0 0 26 26" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
 		<circle cx="12.9985" cy="5.62109" r="4.20947" stroke="currentColor" strokeWidth="2" />
 		<path
@@ -8,3 +8,5 @@ export const User = ({ className }: { className?: string }) => (
 		/>
 	</svg>
 );
+
+export default User;

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -1,14 +1,12 @@
-import { ArrowDown } from './ArrowDown';
-import { BpaLogo } from './BpaLogo';
-import { ChevronLeft } from './ChevronLeft';
-import { ChevronRight } from './ChevronRight';
-import { ChevronsLeft } from './ChevronsLeft';
-import { ChevronsRight } from './ChevronsRight';
-import { Close } from './Close';
-import { Container } from './Container';
-import { Schedule } from './Schedule';
-import { ShipMonitoring } from './ShipMonitoring';
-import { Statistics } from './Statistics';
-import { User } from './User';
-
-export { ArrowDown, BpaLogo, Close, Container, Schedule, ShipMonitoring, Statistics, User, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight };
+export { default as ArrowDown } from './ArrowDown';
+export { default as BpaLogo } from './BpaLogo';
+export { default as ChevronLeft } from './ChevronLeft';
+export { default as ChevronRight } from './ChevronRight';
+export { default as ChevronsLeft } from './ChevronsLeft';
+export { default as ChevronsRight } from './ChevronsRight';
+export { default as Close } from './Close';
+export { default as Container } from './Container';
+export { default as Schedule } from './Schedule';
+export { default as ShipMonitoring } from './ShipMonitoring';
+export { default as Statistics } from './Statistics';
+export { default as User } from './User';


### PR DESCRIPTION
## 요약

유저 주소록 페이지 QA를 반영하였습니다.

## 작업내역

- api 동일 도메인으로 수정(SERVER_URL, CHECK_URL)
- 추가/수정/삭제 시 중복 그룹명 성공 시에만 dialog가 닫히게 수정
- 표 절대 너비로 수정(AddressBookTable.tsx)
- type import 시 \*로 모두 import 후 명시적으로 사용
- pagination default pageSize, totalRows 1/1로 수정
- `TopMenu.tsx` : disabled href 부분 리팩토링(#)
- icons index import를 export {default as \~ } 로 리팩토링